### PR TITLE
show message records

### DIFF
--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -43,6 +43,11 @@
   &__group {
     padding: 20px 0 40px 0;
 
+    &-content {
+      text-decoration: none;
+      color: $fontColorWhite;
+    }
+
     &-name {
       font-size: 15px;
       padding-bottom: 5px;

--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -37,6 +37,7 @@
     background-color: $backgroundColorLightNavy;
     padding: 0 20px;
     height: 85%;
+    overflow: scroll;
   }
 
   &__group {

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -72,6 +72,10 @@
         padding: 0 40px 40px 40px;
         clear: both;
       }
+
+      &-image{
+        padding-left: 40px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/messages.scss
+++ b/app/assets/stylesheets/messages.scss
@@ -42,6 +42,7 @@
     height: calc( 100vh - 15% - 90px);
     background-color: $backgroundColorGray;
     border-top: 1px solid $borderColorGray;
+    overflow: scroll;
 
     &__messeage-list {
       padding-top: 46px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,6 +22,6 @@ class MessagesController < ApplicationController
 
   def set_group
     @group = Group.find(params[:group_id])
-    @message = @group.messages
+    @messages = @group.messages
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
 
   def index
+    set_group
     @message = Message.new
   end
 
@@ -19,4 +20,8 @@ class MessagesController < ApplicationController
     params.require(:message).permit(:body, :image).merge(user_id: current_user.id, group_id: params[:group_id])
   end
 
+  def set_group
+    @group = Group.find(params[:group_id])
+    @message = @group.messages
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,4 +4,12 @@ class Group < ApplicationRecord
   has_many :messages
 
   validates :name, presence: true
+
+  def last_msg
+    if messages.blank?
+      "まだメッセージはありません"
+    else
+      messages.last.body
+    end
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -9,7 +9,11 @@ class Group < ApplicationRecord
     if messages.blank?
       "まだメッセージはありません"
     else
-      messages.last.body
+      if messages.last.image?
+        "画像が投稿されています"
+      else
+        messages.last.body
+      end
     end
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,7 +2,11 @@ class Message < ApplicationRecord
   belongs_to :group
   belongs_to :user
 
-  validates :body, presence: true
+  validates :body_or_image, presence: true
+
+  def body_or_image
+    body.presence or image.presence
+  end
 
   mount_uploader :image, ImageUploader
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,4 +3,6 @@ class Message < ApplicationRecord
   belongs_to :user
 
   validates :body, presence: true
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,4 +1,5 @@
 class ImageUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
 
   storage :file
 
@@ -6,4 +7,15 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  version :thumb do
+    process resize_to_fit: [200, 200]
+  end
+
+  def extension_white_list
+    %W[jpg jpeg gif png]
+  end
+
+  def filename
+    "#{Time.zone.now.strftime('%Y%m%d%H%M%S')}.jpg" if original_filename.present?
+  end
 end

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -10,4 +10,4 @@
       - current_user.groups.each do |group|
         .sidebar__group
           %p.sidebar__group-name #{group.name}
-          %p.sidebar__group-messeage まだメッセージはありません
+          %p.sidebar__group-messeage #{group.last_msg}

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -9,5 +9,6 @@
     .sidebar__groups-list
       - current_user.groups.each do |group|
         .sidebar__group
-          %p.sidebar__group-name #{group.name}
-          %p.sidebar__group-messeage #{group.last_msg}
+          = link_to group_messages_path(group.id), class: "sidebar__group-content" do
+            %p.sidebar__group-name #{group.name}
+            %p.sidebar__group-messeage #{group.last_msg}

--- a/app/views/messages/_message_content.html.haml
+++ b/app/views/messages/_message_content.html.haml
@@ -1,0 +1,9 @@
+.contents__body
+  .contents__body__messeage-list
+    - @messages.each do |message|
+      .contents__body__messeage
+        .contents__body__messeage-name #{message.user.name}
+        .contents__body__messeage-time #{message.created_at.strftime('%Y-%m-%d %H:%M:%S')}
+      .contents__body__messeage-body #{message.body}
+      - if message.image?
+        = image_tag message.image.thumb.url, class: "contents__body__messeage-image"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -13,15 +13,7 @@
     .contents__header__edit
       =link_to "edit", edit_group_path(@group.id), class: "contents__header__edit-btn"
 
-  .contents__body
-    .contents__body__messeage-list
-      - @messages.each do |message|
-        .contents__body__messeage
-          .contents__body__messeage-name #{message.user.name}
-          .contents__body__messeage-time #{message.created_at.strftime('%Y-%m-%d %H:%M:%S')}
-        .contents__body__messeage-body #{message.body}
-        - if message.image?
-          = image_tag message.image.thumb.url, class: "contents__body__messeage-image"
+  = render partial: 'message_content'
 
   .contents__footer
     .contents__footer__form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -15,22 +15,11 @@
 
   .contents__body
     .contents__body__messeage-list
-      .contents__body__messeage
-        .contents__body__messeage-name gyouza
-        .contents__body__messeage-time 2017/09/05 20:52:52
-      .contents__body__messeage-body testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting
-      .contents__body__messeage
-        .contents__body__messeage-name gyouza
-        .contents__body__messeage-time 2017/09/05 20:52:52
-      .contents__body__messeage-body testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting
-      .contents__body__messeage
-        .contents__body__messeage-name gyouza
-        .contents__body__messeage-time 2017/09/05 20:52:52
-      .contents__body__messeage-body testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting
-      .contents__body__messeage
-        .contents__body__messeage-name gyouza
-        .contents__body__messeage-time 2017/09/05 20:52:52
-      .contents__body__messeage-body testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting
+      - @messages.each do |message|
+        .contents__body__messeage
+          .contents__body__messeage-name #{message.user.name}
+          .contents__body__messeage-time #{message.created_at.strftime('%Y-%m-%d %H:%M:%S')}
+        .contents__body__messeage-body #{message.body}
 
   .contents__footer
     .contents__footer__form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,8 +4,11 @@
 .contents
   .contents__header
     .contents__header__infomation
-      %p.contents__header__infomation-name chat-group-3
-      %p.contents__header__infomation-member-name MEMBER: gyouza
+      %p.contents__header__infomation-name #{@group.name}
+      %p.contents__header__infomation-member-name
+        MEMBER:
+        - @group.users.each do |user|
+          #{user.name}
 
     .contents__header__edit
       =link_to "edit", root_path, class: "contents__header__edit-btn"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -20,6 +20,8 @@
           .contents__body__messeage-name #{message.user.name}
           .contents__body__messeage-time #{message.created_at.strftime('%Y-%m-%d %H:%M:%S')}
         .contents__body__messeage-body #{message.body}
+        - if message.image?
+          = image_tag message.image.thumb.url, class: "contents__body__messeage-image"
 
   .contents__footer
     .contents__footer__form

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -11,7 +11,7 @@
           #{user.name}
 
     .contents__header__edit
-      =link_to "edit", root_path, class: "contents__header__edit-btn"
+      =link_to "edit", edit_group_path(@group.id), class: "contents__header__edit-btn"
 
   .contents__body
     .contents__body__messeage-list


### PR DESCRIPTION
# what
メッセージテーブルのレコードをビューに表示。ビューの細部を修正。
- [x] サイドバーにグループ毎の最新メッセージを表示する
- [x] サイドバーのグループ表示領域にスクロール制御追加
- [x] サイドバーのグループをクリック時の画面遷移制御追加
- [x] コンテンツ部にグループメッセージを表示する
- [x] コンテンツ部のメッセージ表示領域にスクロール制御追加
- [x] 画像登録ありのレコードの場合メッセージ表示領域に表示する
- [x] 画像のみの投稿を許容する
- [x] 画像投稿レコードが最終レコードの場合、グループ一覧メッセージに「画像が投稿されています」と表示する


# why
メッセージ内容をビューに表示させるため